### PR TITLE
last-changelog-additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
+
+## [2.1.0] - 2017-10-05
+### Added
+  - New method: `last-changelog-additions` see [README.md](README.md) for more details.
 
 ## [2.0.0] - 2017-10-04
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 [![CircleCI](https://circleci.com/gh/invisible-tech/release-note/tree/master.svg?style=svg)](https://circleci.com/gh/invisible-tech/release-note/tree/master)
 
-Provides two helper functions to publish release notes.
+Provides three helper methods to publish the latest additions to your changelog.
 
-## assert-release-note
+## `assert-release-note`
 
-Asserts if there is a release note in the current Pull Request.
+Asserts if there is an addition to your changelog in the current Pull Request.
 
-## push-release-note
+## `push-release-note`
 
-Pushes the release note to Slack.
+Pushes the changelog additions to Slack (more adapters will be added in the future).
+
+## `last-changelog-additions`
+
+Logs the latest changelog additions to stdout. If you are on `master`, looks at the diff from two merges ago. If you are not on `master`, looks at the diff between `master` and `HEAD`
 
 # Install
 
@@ -32,6 +36,7 @@ npm install -D @invisible/release-note
 
   const {
     assertReleaseNote,
+    lastChangelogAdditions,
     pushReleaseNote,
   } = require('@invisible/release-note')
 
@@ -42,7 +47,7 @@ npm install -D @invisible/release-note
 
   const webhookUrl = process.env.CHANGELOG_WEBHOOK_URL
 
-  // This method is async so it returns a promise that resolves the Response object from POST'ing to the webhook
+  // This method is async so it returns a promise that resolves the Response object from POST'ing to the Slack webhook
   pushReleaseNote({
     changelogFile: 'CHANGELOG.txt', // defaults to CHANGELOG.md
     iconEmoji: 'joy', // defaults to :robot_face:
@@ -50,6 +55,9 @@ npm install -D @invisible/release-note
     webhookUrl,
   }).then(console.log).catch(console.error)
 
+  const notes = lastChangelogAdditions()
+
+  console.log(notes) // or do something cool with it
 ```
 
 ## Hook scripts

--- a/bin/last-changelog-additions
+++ b/bin/last-changelog-additions
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const finder = require('find-package-json')
+const { get } = require('lodash/fp')
+
+const { CHANGELOG_FILE } = require('../src/constants')
+const { lastChangelogAdditions } = require('../src/helpers')
+
+const pkg = finder().next().value || {}
+const changelogFile = get('releaseNote.changelogFile')(pkg) || CHANGELOG_FILE
+
+console.log(lastChangelogAdditions({ changelogFile }))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/release-note",
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Publish Release Notes to Slack seamlessly",
   "engines": {
     "node": "^8.5.0"
@@ -13,8 +13,9 @@
     "url": "https://github.com/invisible-tech"
   },
   "bin": {
-    "push-release-note": "bin/push-release-note",
-    "assert-release-note": "bin/assert-release-note"
+    "assert-release-note": "bin/assert-release-note",
+    "latest-changelog-additions": "bin/latest-changelog-additions",
+    "push-release-note": "bin/push-release-note"
   },
   "main": "index.js",
   "keywords": [

--- a/src/assertReleaseNote.js
+++ b/src/assertReleaseNote.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const { includes } = require('lodash/fp')
 
-const { getLastChangelogAdditions } = require('./helpers')
+const { lastChangelogAdditions } = require('./helpers')
 const { CHANGELOG_FILE } = require('./constants')
 
 const { CIRCLE_BRANCH } = process.env
@@ -12,7 +12,7 @@ const shouldIgnore = branch => includes(branch)(IGNORED_BRANCHES)
 
 const run = ({ changelogFile = CHANGELOG_FILE } = {}) => {
   if (shouldIgnore(CIRCLE_BRANCH)) return
-  const additions = getLastChangelogAdditions({ changelogFile, commitHash: 'master' })
+  const additions = lastChangelogAdditions({ changelogFile })
   assert(additions, `release-note: no additions to ${changelogFile} found`)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 'use strict'
 
+const assertReleaseNote = require('./assertReleaseNote')
+const pushReleaseNote = require('./pushReleaseNote')
+const { lastChangelogAdditions } = require('./helpers')
+
 module.exports = {
-  assertReleaseNote: require('./assertReleaseNote'),
-  pushReleaseNote: require('./pushReleaseNote'),
+  assertReleaseNote,
+  lastChangelogAdditions,
+  pushReleaseNote,
 }

--- a/src/pushReleaseNote.js
+++ b/src/pushReleaseNote.js
@@ -4,36 +4,19 @@
 
 const assert = require('assert')
 const got = require('got')
-const spawn = require('cross-spawn')
 const {
-  last,
-  split,
   toLower,
   trimChars,
 } = require('lodash/fp')
 
-const { getLastChangelogAdditions } = require('./helpers')
+const {
+  lastChangelogAdditions,
+} = require('./helpers')
 const {
   CHANGELOG_FILE,
   ICON_EMOJI,
   SLACKBOT_NAME,
 } = require('./constants')
-
-const getLastMergeHash = () => {
-  const { stdout: mergeHashes } = spawn.sync(
-    'git',
-    [
-      '--no-pager',
-      'log',
-      '--merges',
-      '-2',
-      '--pretty=format:%h',
-    ],
-    { encoding: 'utf8' }
-  )
-
-  return last(split('\n')(mergeHashes))
-}
 
 const postToWebhook = async ({ payload, webhookUrl }) => {
   const options = {
@@ -56,9 +39,8 @@ const run = async ({
   webhookUrl,
 }) => {
   assert(webhookUrl, 'release-note: no webhook url given')
-  const text = getLastChangelogAdditions({
+  const text = lastChangelogAdditions({
     changelogFile,
-    commitHash: getLastMergeHash(),
   })
   const payload = JSON.stringify({
     icon_emoji: normalizeEmoji(iconEmoji),


### PR DESCRIPTION
Adds function and cli for getting the last changelog additions as text. This can be used further to create github release notes, etc.

Based on #9 so review after that is merged.