### PR TITLE
Add feedback for assert-changelog-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+
+
 ## [1.0.6] - 2017-10-06
 ### Changed
   - Fixed: config should be camelCase and not PascalCase in `package.json`
@@ -29,3 +31,4 @@ All notable changes to this project will be documented in this file.
 [1.0.3]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.3
 [1.0.4]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.4
 [1.0.5]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.5
+[1.0.6]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.5] - 2017-10-06
+### Changed
+  - Fixed: incorrect `bin` specification in `package.json`
+
+## [1.0.4] - 2017-10-06
+### Changed
+  - Made bin `assert-changelog-update` visible feedback optional with `-q` or `--quiet` option
+
+## [1.0.3] - 2017-10-06
+### Changed
+  - Added some visible feedback for bin `assert-changelog-update`
+
 ## [1.0.2] - 2017-10-06
 ### Added
   - Initial add: see [README.md](README.md) for details.
@@ -10,3 +22,6 @@ All notable changes to this project will be documented in this file.
   - Renamed from https://github.com/invisible-tech/release-note , no change in functionality
 
 [1.0.2]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.2
+[1.0.3]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.3
+[1.0.4]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.4
+[1.0.5]: https://github.com/invisible-tech/changelog-update/releases/tag/v1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.6] - 2017-10-06
+### Changed
+  - Fixed: config should be camelCase and not PascalCase in `package.json`
+
 ## [1.0.5] - 2017-10-06
 ### Changed
   - Fixed: incorrect `bin` specification in `package.json`

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ npm install -D @invisible/changelog-update
 
 You can also run it at any time from your CLI.
 ```
-$ assert-changelog-update
+$ assert-changelog-update # will output the change if found
+$ assert-changelog-update --quiet # will silently succeed, but output error if not found
 ```
 
 ### `push-changelog-update`
@@ -100,7 +101,8 @@ $ push-changelog-update
 ```JSON
   "ChangelogUpdate": {
     "slackbotName": "Changelog Robot",
-    "iconEmoji": "joy"
+    "iconEmoji": "joy",
+    "changelogFile: "CHANGELOG" // defaults to CHANGELOG.md
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 Provides three helper methods to publish the latest additions to your changelog.
 
-## `assert-changelog-update`
+1. `assert-changelog-update`
 
-Asserts if there is an addition to your changelog in the current, unmerged branch.
+    Asserts if there is an addition to your changelog in the current, unmerged branch.
 
-## `push-changelog-update`
+2. `push-changelog-update`
 
-Pushes the changelog additions to Slack (more adapters will be added in the future).
+    Pushes the changelog additions to Slack (more adapters will be added in the future).
 
-## `last-changelog-update`
+3. `last-changelog-update`
 
-Logs the latest changelog additions to stdout. If you are on `master`, looks at the diff from two merges ago. If you are not on `master`, looks at the diff between `master` and `HEAD`
+    Logs the latest changelog additions to stdout. If you are on `master`, looks at the diff from two merges ago. If you are not on `master`, looks at the diff between `master` and `HEAD`
 
-# Install
+## Install
 
 1. Install the package as devDependency:
 ```sh
@@ -27,9 +27,9 @@ npm install -D @invisible/changelog-update
 
 2. If you wish to use `push-changelog-update`, set up a [Slack Webhook](https://my.slack.com/services/new/incoming-webhook/). NOTE: Slack will reject mutliple `POST`'s to the same webhook that have identical messages, so you might run into this while testing.
 
-# Usage
+## Usage
 
-## Programmatically
+### Programmatically
 
 ```javascript
   'use strict'
@@ -61,9 +61,9 @@ npm install -D @invisible/changelog-update
   console.log(notes) // or do something cool with it
 ```
 
-## Hook scripts
+### Hook scripts
 
-### `assert-changelog-update`
+#### `assert-changelog-update`
 1. Append `assert-changelog-update` to `posttest` on `scripts` section of your `package.json`.
 ```json
   // It would look something like this:
@@ -78,36 +78,40 @@ $ assert-changelog-update # will output the change if found
 $ assert-changelog-update --quiet # will silently succeed, but output error if not found
 ```
 
-### `push-changelog-update`
-1. Add to the `deployment` section of your project `circle.yml` file the following:
-`- push-changelog-update`
+#### `push-changelog-update`
+1. If using Circle CI, add `push-changelog-update` to the `deployment` section of your project `circle.yml`.
 
-```yaml
-# Your circle.yml should look like the below:
-deployment:
-  production:
-    branch: master
-    commands:
-      - push-changelog-update
-```
+    `- push-changelog-update`
 
-You can also run it at any time from your CLI.
-```
-$ push-changelog-update
-```
+    ```yaml
+      # ...
+      deployment:
+        production:
+          branch: master
+          commands:
+            - push-changelog-update
+    ```
 
-2. Optional: set a name for your slack bot and an icon emoji in your `package.json`
+    Add the `CHANGELOG_WEBHOOK_URL` env variable to your project too.
+    This package will optionally load `dotenv` if it's present, so you may add this to your `.env` file as well.
 
-```JSON
-  "ChangelogUpdate": {
-    "slackbotName": "Changelog Robot",
-    "iconEmoji": "joy",
-    "changelogFile: "CHANGELOG" // defaults to CHANGELOG.md
-  }
-```
+    You can also run it at any time from your CLI.
 
-3. If using Circle CI, add the `CHANGELOG_WEBHOOK_URL` variable to your project. This package will optionally load `dotenv` if it's present, so you may add this to your `.env` file as well.
+    ```
+    $ push-changelog-update
+    ```
 
-## TODO
+2. Optional: set a name for your slack bot and an icon emoji in your [`package.json`](package.json)
+
+    ```JSON
+      "changelogUpdate": {
+        "slackbotName": "Changelog Robot", // defaults to project name
+        "iconEmoji": "joy", // defaults to :robot_face:
+        "changelogFile: "CHANGELOG" // defaults to CHANGELOG.md
+      }
+    ```
+
+
+### TODO
 - Unit Tests
 - Testing on multiple platforms

--- a/bin/assert-changelog-update
+++ b/bin/assert-changelog-update
@@ -2,21 +2,20 @@
 
 'use strict'
 
-const finder = require('find-package-json')
 const { get } = require('lodash/fp')
 
 const assertChangelogUpdate = require('../src/assertChangelogUpdate')
-const { lastChangelogUpdate } = require('../src/helpers')
-const { CHANGELOG_FILE } = require('../src/constants')
+const {
+  lastChangelogUpdate,
+  getArgumentsWithDefaults,
+} = require('../src/helpers')
 
-const pkg = finder().next().value || {}
-
-const changelogFile = get('ChangelogUpdate.changelogFile')(pkg) || CHANGELOG_FILE
+const { changelogFile } = getArgumentsWithDefaults()
 
 try {
   assertChangelogUpdate({ changelogFile })
   const isQuiet = (process.argv[2] && (process.argv[2] === '-q' || process.argv[2] === '--quiet'))
-  if (! isQuiet) console.log(`Changelog update found\n${lastChangelogUpdate()}`)
+  if (! isQuiet) console.log(`Changelog update found\n${lastChangelogUpdate({ changelogFile })}`)
   process.exit(0)
 } catch (err) {
   console.error(err)

--- a/bin/assert-changelog-update
+++ b/bin/assert-changelog-update
@@ -6,10 +6,19 @@ const finder = require('find-package-json')
 const { get } = require('lodash/fp')
 
 const assertChangelogUpdate = require('../src/assertChangelogUpdate')
+const { lastChangelogUpdate } = require('../src/helpers')
 const { CHANGELOG_FILE } = require('../src/constants')
 
 const pkg = finder().next().value || {}
 
 const changelogFile = get('ChangelogUpdate.changelogFile')(pkg) || CHANGELOG_FILE
 
-assertChangelogUpdate({ changelogFile })
+try {
+  assertChangelogUpdate({ changelogFile })
+  const isQuiet = (process.argv[2] && (process.argv[2] === '-q' || process.argv[2] === '--quiet'))
+  if (! isQuiet) console.log(`Changelog update found\n${lastChangelogUpdate()}`)
+  process.exit(0)
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}

--- a/bin/last-changelog-update
+++ b/bin/last-changelog-update
@@ -2,13 +2,14 @@
 
 'use strict'
 
-const finder = require('find-package-json')
 const { get } = require('lodash/fp')
 
 const { CHANGELOG_FILE } = require('../src/constants')
-const { lastChangelogUpdate } = require('../src/helpers')
+const {
+  getArgumentsWithDefaults,
+  lastChangelogUpdate,
+} = require('../src/helpers')
 
-const pkg = finder().next().value || {}
-const changelogFile = get('ChangelogUpdate.changelogFile')(pkg) || CHANGELOG_FILE
+const { changelogFile } = getArgumentsWithDefaults()
 
 console.log(lastChangelogUpdate({ changelogFile }))

--- a/bin/push-changelog-update
+++ b/bin/push-changelog-update
@@ -15,13 +15,13 @@ const {
 
 const pkg = finder().next().value || {}
 const {
-  ChangelogUpdate: {
+  changelogUpdate: {
     changelogFile = CHANGELOG_FILE,
     iconEmoji = ICON_EMOJI,
   } = {},
 } = pkg
 
-const slackbotName = get('ChangelogUpdate.slackbotName')(pkg) ||
+const slackbotName = get('changelogUpdate.slackbotName')(pkg) ||
   get('name')(pkg) ||
   SLACKBOT_NAME
 

--- a/bin/push-changelog-update
+++ b/bin/push-changelog-update
@@ -2,28 +2,13 @@
 
 'use strict'
 
-const finder = require('find-package-json')
 const { get } = require('lodash/fp')
 const { stripIndents } = require('common-tags')
 
 const pushChangelogUpdate = require('../src/pushChangelogUpdate')
-const {
-  CHANGELOG_FILE,
-  ICON_EMOJI,
-  SLACKBOT_NAME,
-} = require('../src/constants')
+const { getArgumentsWithDefaults } = require('../src/helpers')
 
-const pkg = finder().next().value || {}
-const {
-  changelogUpdate: {
-    changelogFile = CHANGELOG_FILE,
-    iconEmoji = ICON_EMOJI,
-  } = {},
-} = pkg
-
-const slackbotName = get('changelogUpdate.slackbotName')(pkg) ||
-  get('name')(pkg) ||
-  SLACKBOT_NAME
+const { changelogFile, iconEmoji, slackbotName } = getArgumentsWithDefaults()
 
 try {
   const dotenv = require('dotenv')

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,11 @@
 dependencies:
+  pre:
+    # Install yarn
+    - curl -o- -L https://yarnpkg.com/install.sh | bash
   override:
     - yarn
+  cache_directories:
+    - ~/.cache/yarn
 
 machine:
   environment:
@@ -9,8 +14,6 @@ machine:
 
   node:
     version: "8.5.0"
-
-  timezone: America/Los_Angeles
 
 test:
   override:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/changelog-update",
   "license": "MIT",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Ensure updates to your changelog, and push them to Slack seamlessly",
   "engines": {
     "node": "^8.5.0"
@@ -59,5 +59,9 @@
   },
   "optionalDependencies": {
     "dotenv": "^4.0.0"
+  },
+  "changelogUpdate": {
+    "iconEmoji": "bellhop_bell",
+    "slackbotName": "Changelog Update"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/changelog-update",
   "license": "MIT",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Ensure updates to your changelog, and push them to Slack seamlessly",
   "engines": {
     "node": "^8.5.0"
@@ -48,7 +48,7 @@
     "prepublishOnly": "nsp check",
     "pretest": "yarn run lint",
     "test": "exit 0",
-    "posttest": "assert-version-bump && bin/assert-changelog-update"
+    "posttest": "assert-version-bump && bin/assert-changelog-update --quiet"
   },
   "dependencies": {
     "common-tags": "^1.4.0",

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -52,7 +52,6 @@ const lastMergeHash = () => {
 const changelogCommitHash = () =>
   (currentBranch() === MASTER ? lastMergeHash() : MASTER)
 
-
 const lastChangelogUpdate = ({ changelogFile = CHANGELOG_FILE, commitHash } = {}) => {
   const { stdout: diff } = spawn.sync(
     'git',


### PR DESCRIPTION
Based on #11, so rebase after it is merged. Note, this is already published to npm. After these get merged I will rename the actual repo on github.