### PR TITLE
Fix: lastChangelogUpdate consume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > All notable changes to this project will be documented in this file.
 
+## [1.0.9] - 2017-11-08
+### Fix
+  - The main file and expose lastChangelogUpdate.
+
 ## [1.0.8] - 2017-10-11
 ### Added
   - Allow user to customize master branch and remote master branch, default to `origin/master`
@@ -40,3 +44,4 @@
 [1.0.6]: https://github.com/invisible-tech/changelog-update/compare/v1.0.5...v1.0.6
 [1.0.7]: https://github.com/invisible-tech/changelog-update/compare/v1.0.6...v1.0.7
 [1.0.8]: https://github.com/invisible-tech/changelog-update/compare/v1.0.7...v1.0.8
+[1.0.9]: https://github.com/invisible-tech/changelog-update/compare/v1.0.8...v1.0.9

--- a/bin/last-changelog-update
+++ b/bin/last-changelog-update
@@ -2,10 +2,8 @@
 
 'use strict'
 
-const {
-  getArgumentsWithDefaults,
-  lastChangelogUpdate,
-} = require('../src/helpers')
+const lastChangelogUpdate = require('../src/lastChangelogUpdate')
+const { getArgumentsWithDefaults } = require('../src/helpers')
 
 const { changelogFile } = getArgumentsWithDefaults()
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,0 @@
-'use strict'
-
-module.exports = {
-  assertChangelogUpdate: require('./src/assertChangelogUpdate'),
-  pushChangelogUpdate: require('./src/pushChangelogUpdate'),
-}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/changelog-update",
   "license": "MIT",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Ensure updates to your changelog, and push them to Slack seamlessly",
   "engines": {
     "node": "^8.5.0"
@@ -17,7 +17,7 @@
     "last-changelog-update": "bin/last-changelog-update",
     "push-changelog-update": "bin/push-changelog-update"
   },
-  "main": "index.js",
+  "main": "src/index.js",
   "keywords": [
     "slack",
     "release",

--- a/src/assertChangelogUpdate.js
+++ b/src/assertChangelogUpdate.js
@@ -4,17 +4,17 @@ const assert = require('assert')
 const { includes } = require('lodash/fp')
 
 const {
+  currentBranch,
   changelogCommitHash,
   lastChangelogUpdate,
 } = require('./helpers')
 const { CHANGELOG_FILE } = require('./constants')
 
-const { CIRCLE_BRANCH } = process.env
 const IGNORED_BRANCHES = ['master', 'production', 'staging']
 const shouldIgnore = branch => includes(branch)(IGNORED_BRANCHES)
 
 const run = ({ changelogFile = CHANGELOG_FILE } = {}) => {
-  if (shouldIgnore(CIRCLE_BRANCH)) return
+  if (shouldIgnore(currentBranch())) return
   const additions = lastChangelogUpdate({ changelogFile })
   const hash = changelogCommitHash()
   assert(additions, `changelog-update: no additions to ${changelogFile} found since ${hash}`)

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -106,5 +106,6 @@ const getArgumentsWithDefaults = () => {
 module.exports = {
   getArgumentsWithDefaults,
   changelogCommitHash,
+  currentBranch,
   lastChangelogUpdate,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const assertChangelogUpdate = require('./assertChangelogUpdate')
 const pushChangelogUpdate = require('./pushChangelogUpdate')
-const { lastChangelogUpdate } = require('./helpers')
+const lastChangelogUpdate = require('./lastChangelogUpdate')
 
 module.exports = {
   assertChangelogUpdate,

--- a/src/lastChangelogUpdate.js
+++ b/src/lastChangelogUpdate.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { lastChangelogUpdate } = require('./helpers')
+const { CHANGELOG_FILE } = require('./constants')
+
+const run = ({ changelogFile = CHANGELOG_FILE, commitHash } = {}) =>
+  lastChangelogUpdate({ changelogFile, commitHash })
+
+module.exports = run


### PR DESCRIPTION
The main file was not exposing `lastChangelogUpdate`. Just fixing that and following the same standard as used in `assertChangelogUpdate` and `pushChangelogUpdate`.