### PR TITLE
Automatic Log Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2019-04-11
+### Feature
+  - Add automatic changelog generation based on commit messages.
+
 ## [1.2.2] - 2018-12-17
 ### Internal
   - Migrated to npm from yarn

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ npm install -D @invisible/changelog-update
   ```bash
   $ push-changelog-update
   $ push-changelog-update --strict # will silently succeed, but, output error if no changelog found without stopping the execution.
+  $ push-changelog-update --generate # will generate a changelog based on commit messages.
   ```
 
 2. To ensure that `assert-changelog-update` is run properly, make your `test` section in `circle.yml` look like this:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Provides three helper methods to publish the latest additions to your changelog.
 
     Logs the latest changelog additions to stdout. If you are on `master`, looks at the diff from two merges ago. If you are not on `master`, looks at the diff between `master` and `HEAD`
 
+3. `generate-changelog`
+
+    Logs the latest commits to stdout. If you are on `master`, looks at the log from two merges ago. If you are not on `master`, looks at the log between `master` and `HEAD`.
+
 ## Install
 
 1. Install the package as devDependency:

--- a/bin/generate-changelog
+++ b/bin/generate-changelog
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const generateChangelog = require('../src/generateChangelog')
+
+console.log(generateChangelog({}))

--- a/bin/push-changelog-update
+++ b/bin/push-changelog-update
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const yargs = require('yargs')
 const { stripIndents } = require('common-tags')
 
 const pushChangelogUpdate = require('../src/pushChangelogUpdate')
@@ -9,11 +10,16 @@ const { getArgumentsWithDefaults } = require('../src/helpers')
 
 const { changelogFile, iconEmoji, slackbotName } = getArgumentsWithDefaults()
 
-const { argv } = require('yargs')
+const { argv } = yargs
   .option('strict', {
     boolean: true,
     alias: 's',
     default: true,
+  })
+  .option('generate', {
+    boolean: true,
+    alias: 'g',
+    default: false,
   })
   .version()
   .help()
@@ -32,8 +38,10 @@ if (! webhookUrl) {
   process.exit(1)
 }
 
-pushChangelogUpdate({ webhookUrl, changelogFile, iconEmoji, slackbotName }).then(
-  res => ((argv.strict) ? undefined : console.log(
+const { strict, generate } = argv
+
+pushChangelogUpdate({ webhookUrl, changelogFile, iconEmoji, slackbotName, generate }).then(
+  res => ((strict) ? undefined : console.log(
     stripIndents`
       changelog-update:
       STATUS: ${res.statusCode}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@invisible/changelog-update",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2309,6 +2309,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3251,7 +3252,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "bin": {
     "assert-changelog-update": "bin/assert-changelog-update",
+    "generate-changelog": "bin/generate-changelog",
     "last-changelog-update": "bin/last-changelog-update",
     "push-changelog-update": "bin/push-changelog-update"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/changelog-update",
   "license": "MIT",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Ensure updates to your changelog, and push them to Slack seamlessly",
   "engines": {
     "node": ">=8.11.2",

--- a/src/generateChangelog.js
+++ b/src/generateChangelog.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { generateChangelog } = require('./helpers')
+
+const run = generateChangelog
+
+module.exports = run

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -80,6 +80,19 @@ const lastChangelogUpdate = ({ changelogFile = CHANGELOG_FILE, commitHash } = {}
   return getAdditions(diff)
 }
 
+const generateChangelog = ({ commitHash } = {}) => {
+  const { stdout: log } = spawn.sync(
+    'git',
+    [
+      'log',
+      '--pretty=format:%B',
+      `${commitHash || changelogCommitHash()}..HEAD`,
+    ],
+    { encoding: 'utf8' }
+  )
+  return log
+}
+
 const getArgumentsWithDefaults = () => {
   const {
     changelogUpdate: {
@@ -104,6 +117,7 @@ const getArgumentsWithDefaults = () => {
 }
 
 module.exports = {
+  generateChangelog,
   getArgumentsWithDefaults,
   changelogCommitHash,
   currentBranch,

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const assertChangelogUpdate = require('./assertChangelogUpdate')
-const pushChangelogUpdate = require('./pushChangelogUpdate')
+const generateChangelog = require('./generateChangelog')
 const lastChangelogUpdate = require('./lastChangelogUpdate')
+const pushChangelogUpdate = require('./pushChangelogUpdate')
 
 module.exports = {
   assertChangelogUpdate,
+  generateChangelog,
   lastChangelogUpdate,
   pushChangelogUpdate,
 }


### PR DESCRIPTION
Hey, I want to add this to all our projects in Yggdrasil so we have a consistent place to check changes daily.
It will also push us towards writing better commit messages and properly squashing our commits.

For this branch:
```
$ ./bin/generate-changelog
chore: Bump version and update CHANGELOG

feat: Add --generate flag to push-changelog-update

If flag is used, the script pushes the generated changelog.

feat: Add commit message based changelog generation

```